### PR TITLE
fix: remove icon size from side rail items

### DIFF
--- a/packages/aes_ui/lib/src/theme/aes_theme.dart
+++ b/packages/aes_ui/lib/src/theme/aes_theme.dart
@@ -13,8 +13,8 @@ class AesTheme {
       useMaterial3: true,
       navigationRailTheme: const NavigationRailThemeData(
         labelType: NavigationRailLabelType.none,
-        selectedIconTheme: IconThemeData(size: 36, color: Colors.red),
-        unselectedIconTheme: IconThemeData(size: 36, color: Colors.black),
+        selectedIconTheme: IconThemeData(color: Colors.red),
+        unselectedIconTheme: IconThemeData(color: Colors.black),
         groupAlignment: 0,
       ),
       navigationBarTheme: NavigationBarThemeData(


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
Removes the icon size from the icon in the side navigation rail.

![image](https://github.com/user-attachments/assets/466f0888-a4de-499c-93a2-72ff12cd4cbc)


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
