### PR TITLE
fix: wrap header Text widgets in FittedBox

### DIFF
--- a/lib/music_player/view/music_player_page.dart
+++ b/lib/music_player/view/music_player_page.dart
@@ -449,8 +449,6 @@ class _MusicMenuHeader extends StatelessWidget {
           child: Text(
             l10n.goodVibes,
             style: AesTextStyles.headlineLarge,
-            overflow: TextOverflow.ellipsis,
-            maxLines: 2,
           ),
         ),
         const SizedBox(height: 10),

--- a/lib/overview/view/overview_page.dart
+++ b/lib/overview/view/overview_page.dart
@@ -97,9 +97,7 @@ class WelcomeCopy extends StatelessWidget {
         FittedBox(
           child: Text(
             l10n.welcomeMessage,
-            maxLines: 2,
             style: AesTextStyles.headlineLarge,
-            overflow: TextOverflow.ellipsis,
           ),
         ),
         const SizedBox(height: 10),


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
On smaller screens, the page headers were getting truncated. This PR wraps those `Text` widgets in a `FittedBox` so the text will scale according to the screen size.


https://github.com/user-attachments/assets/4a56fe3c-62a7-41de-9b6a-d860c7c8feaf


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
